### PR TITLE
reactive-resume

### DIFF
--- a/charts/reactive-resume/Chart.yaml
+++ b/charts/reactive-resume/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: reactive-resume
+description: A Helm chart for Reactive-Resume
+version: 0.1.0
+appVersion: "1.0.0"
+dependencies:
+  - name: minio
+    version: 14.10.3
+    repository: https://charts.bitnami.com/bitnami
+  - name: postgresql
+    version: 16.3.4
+    repository: https://charts.bitnami.com/bitnami

--- a/charts/reactive-resume/_helpers.tpl
+++ b/charts/reactive-resume/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/*
+Common labels
+*/}}
+{{- define "gotrue.labels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "appflowy.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/reactive-resume/templates/_helpers.tpl
+++ b/charts/reactive-resume/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "reactive-resume.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | lower }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "reactive-resume.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" | lower }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" | lower }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" | lower }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "reactive-resume.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" | lower }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "reactive-resume.labels" -}}
+helm.sh/chart: {{ include "reactive-resume.chart" . }}
+{{ include "reactive-resume.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "reactive-resume.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "reactive-resume.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/reactive-resume/templates/deployment.yaml
+++ b/charts/reactive-resume/templates/deployment.yaml
@@ -1,0 +1,134 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "reactive-resume.fullname" . }}-app
+  labels:
+    {{- include "reactive-resume.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.app.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "reactive-resume.selectorLabels" . | nindent 6 }}
+      component: app
+  template:
+    metadata:
+      labels:
+        {{- include "reactive-resume.selectorLabels" . | nindent 8 }}
+        component: app
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}"
+          imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+          ports:
+            - containerPort: 3000
+          env:
+            - name: PORT
+              value: "3000"
+            - name: NODE_ENV
+              value: "production"
+            - name: PUBLIC_URL
+              value: {{ .Values.app.config.publicUrl }}
+            - name: STORAGE_URL
+              # value: {{ .Values.app.config.storageUrl }}
+              value: {{ .Values.app.config.storageUrl | default (printf "http://%s-minio:9000" .Release.Name) }}
+
+            # Chrome configuration
+            - name: CHROME_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "reactive-resume.fullname" . }}
+                  key: chrome-token
+            - name: CHROME_URL
+              value: "ws://{{ include "reactive-resume.fullname" . }}-chrome:3000"
+
+            # Database configuration
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "reactive-resume.fullname" . }}
+                  key: database-url
+
+            # Auth configuration
+            - name: ACCESS_TOKEN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "reactive-resume.fullname" . }}
+                  key: access-token-secret
+            - name: REFRESH_TOKEN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "reactive-resume.fullname" . }}
+                  key: refresh-token-secret
+
+            # Email configuration
+            - name: MAIL_FROM
+              value: {{ .Values.app.config.mailFrom }}
+            - name: DISABLE_SIGNUPS
+              value: {{ .Values.app.config.disableSignups | default false | quote }}
+            - name: DISABLE_EMAIL_AUTH
+              value: {{ .Values.app.config.disableEmailAuth | default false | quote }}
+
+            # MinIO configuration
+            - name: STORAGE_ENDPOINT
+              value: {{ printf "%s-minio" .Release.Name }}
+              # value: {{ .Values.minio.host }}
+            - name: STORAGE_PORT
+              value: {{ .Values.minio.port | default 9000 | quote }}
+            - name: STORAGE_REGION
+              value: {{ .Values.minio.region | default "" }}
+            - name: STORAGE_BUCKET
+              value: {{ .Values.minio.defaultBuckets }}
+            - name: STORAGE_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "reactive-resume.fullname" . }}
+                  key: storage-access-key
+            - name: STORAGE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "reactive-resume.fullname" . }}
+                  key: storage-secret-key
+            - name: STORAGE_USE_SSL
+              value: {{ .Values.minio.useSsl | default false | quote }}
+            - name: STORAGE_SKIP_BUCKET_CHECK
+              value: {{ .Values.minio.skipBucketCheck | default false | quote }}
+          resources:
+            {{- toYaml .Values.app.resources | nindent 12 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "reactive-resume.fullname" . }}-chrome
+  labels:
+    {{- include "reactive-resume.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.chrome.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "reactive-resume.selectorLabels" . | nindent 6 }}
+      component: chrome
+  template:
+    metadata:
+      labels:
+        {{- include "reactive-resume.selectorLabels" . | nindent 8 }}
+        component: chrome
+    spec:
+      containers:
+        - name: chrome
+          image: "{{ .Values.chrome.image.repository }}:{{ .Values.chrome.image.tag }}"
+          imagePullPolicy: {{ .Values.chrome.image.pullPolicy }}
+          ports:
+            - containerPort: 3000
+          env:
+            - name: TIMEOUT
+              value: {{ .Values.chrome.config.timeout | quote }}
+            - name: CONCURRENT
+              value: {{ .Values.chrome.config.concurrent | quote }}
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "reactive-resume.fullname" . }}
+                  key: chrome-token
+          resources:
+            {{- toYaml .Values.chrome.resources | nindent 12 }}

--- a/charts/reactive-resume/templates/secret.yaml
+++ b/charts/reactive-resume/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "reactive-resume.fullname" . | lower }}
+type: Opaque
+stringData:
+  chrome-token: {{ .Values.app.config.chromeToken }}
+  database-url: postgresql://{{ .Values.postgresql.global.postgresql.auth.username }}:{{ .Values.postgresql.global.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:{{ .Values.postgresql.global.postgresql.service.ports.postgresql | default 5432 }}/{{ .Values.postgresql.global.postgresql.auth.database }}
+  access-token-secret: {{ .Values.app.config.accessTokenSecret }}
+  refresh-token-secret: {{ .Values.app.config.refreshTokenSecret }}
+  storage-access-key: {{ .Values.minio.auth.rootUser }}
+  storage-secret-key: {{ .Values.minio.auth.rootPassword }}

--- a/charts/reactive-resume/templates/service.yaml
+++ b/charts/reactive-resume/templates/service.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "reactive-resume.fullname" . }}-app
+  labels:
+    {{- include "reactive-resume.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.app.service.type }}
+  ports:
+    - port: {{ .Values.app.service.port }}
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "reactive-resume.selectorLabels" . | nindent 4 }}
+    component: app
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "reactive-resume.fullname" . }}-chrome
+  labels:
+    {{- include "reactive-resume.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.chrome.service.type }}
+  ports:
+    - port: {{ .Values.chrome.service.port }}
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "reactive-resume.selectorLabels" . | nindent 4 }}
+    component: chrome

--- a/charts/reactive-resume/values.yaml
+++ b/charts/reactive-resume/values.yaml
@@ -1,0 +1,77 @@
+nameOverride: ""
+fullnameOverride: ""
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+app:
+  replicaCount: 1
+  image:
+    repository: amruthpillai/reactive-resume
+    pullPolicy: IfNotPresent
+    tag: "latest"
+  service:
+    type: ClusterIP
+    port: 3000
+  resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  config:
+    publicUrl: "https://resume.voidbox.io"
+    # storageUrl: "http://localhost:9000/default"
+    chromeToken: "chrome_token"
+    accessTokenSecret: "access_token_secret"
+    refreshTokenSecret: "refresh_token_secret"
+    mailFrom: "noreply@localhost"
+    disableSignups: false
+    disableEmailAuth: false
+#####################################################
+chrome:
+  replicaCount: 1
+  image:
+    repository: ghcr.io/browserless/chromium
+    pullPolicy: IfNotPresent
+    tag: "latest"
+  service:
+    type: ClusterIP
+    port: 3000
+  resources: {}
+  config:
+    timeout: 10000
+    concurrent: 10
+    token: "chrome_token"
+    exitOnHealthFailure: true
+    preRequestHealthCheck: true
+#####################################################
+minio:
+  global:
+    defaultStorageClass: "nfs-client"
+  auth:
+    rootUser: "minioadmin"
+    rootPassword: "minioadmin"
+  defaultBuckets: "default"
+#####################################################
+postgresql:
+  global:
+    defaultStorageClass: "nfs-client"
+    security:
+      allowInsecureImages: true
+    postgresql:
+      auth:
+        username: "postgres"
+        password: "postgres"
+        database: "postgres"
+        # service:
+        #   ports:
+        #     postgresql: "5432"
+  image:
+    registry: docker.io
+    repository: loneexile/pgvector
+    tag: "20250101"
+    pullPolicy: Always
+#####################################################


### PR DESCRIPTION
This pull request introduces a Helm chart for deploying the Reactive-Resume application. The changes include defining the chart's metadata, templates for Kubernetes resources, and configuration values.

Key changes:

### Chart Metadata:
* Added `Chart.yaml` to define the chart's metadata, including dependencies on MinIO and PostgreSQL.

### Template Definitions:
* Created `_helpers.tpl` for common labels and naming conventions.
* Added deployment templates for the Reactive-Resume app and Chrome service in `deployment.yaml`.
* Defined a secret template in `secret.yaml` to manage sensitive data like tokens and database credentials.
* Added service templates in `service.yaml` to expose the Reactive-Resume app and Chrome service.

### Configuration Values:
* Defined configuration values in `values.yaml` for customizing the deployment, including image repositories, service types, and resource limits.